### PR TITLE
Fixes jenkins polling jobs templates, fixes reusing existing workspace

### DIFF
--- a/api_poll/api-server-poll.yml
+++ b/api_poll/api-server-poll.yml
@@ -42,6 +42,7 @@
                   sudo docker rmi {image_under_test}
                 else
                     echo "Success report scan has been requested for this"
+                    rm -f do_not_poll
                     jenkins-jobs --ignore-cache --conf ~/jenkins_jobs.ini delete  {api_server_poll_job_name}
                 fi
             else

--- a/api_poll/api-server-poll.yml
+++ b/api_poll/api-server-poll.yml
@@ -43,14 +43,14 @@
                 else
                     echo "Success report scan has been requested for this"
                     rm -f do_not_poll counter.txt
-                    jenkins-jobs --ignore-cache --conf ~/jenkins_jobs.ini delete  {api_server_poll_job_name}
+                    jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini delete  {api_server_poll_job_name}
                 fi
             else
                 gemini_report=False
                 echo "Gemini server polling timed out"
                 python /opt/scanning/api_poll/send_scan_data_to_tube.py  {analytics_server} {image_under_test} {git_url} {git_sha} {logs_dir} $gemini_report
                 rm -f do_not_poll counter.txt
-                jenkins-jobs --ignore-cache --conf ~/jenkins_jobs.ini delete  {api_server_poll_job_name}
+                jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini delete  {api_server_poll_job_name}
             fi
             COUNTER=$((COUNTER+1))
             rm -rf counter.txt

--- a/api_poll/api-server-poll.yml
+++ b/api_poll/api-server-poll.yml
@@ -25,7 +25,7 @@
               COUNTER=0
             fi
 
-            echo "This is $COUNTER no run"
+            echo "This is $COUNTER number run .."
 
             if [ $COUNTER -lt 24 ]; then
                 if [ ! -f do_not_poll ]; then
@@ -42,13 +42,14 @@
                   sudo docker rmi {image_under_test}
                 else
                     echo "Success report scan has been requested for this"
-                    rm -f do_not_poll
+                    rm -f do_not_poll counter.txt
                     jenkins-jobs --ignore-cache --conf ~/jenkins_jobs.ini delete  {api_server_poll_job_name}
                 fi
             else
                 gemini_report=False
                 echo "Gemini server polling timed out"
                 python /opt/scanning/api_poll/send_scan_data_to_tube.py  {analytics_server} {image_under_test} {git_url} {git_sha} {logs_dir} $gemini_report
+                rm -f do_not_poll counter.txt
                 jenkins-jobs --ignore-cache --conf ~/jenkins_jobs.ini delete  {api_server_poll_job_name}
             fi
             COUNTER=$((COUNTER+1))

--- a/api_poll/api-server-poll.yml
+++ b/api_poll/api-server-poll.yml
@@ -14,7 +14,7 @@
     description: |
         Managed by Jenkins Job Builder, do not edit manually!
     triggers:
-      - timed: "H/2 * * * *"
+      - timed: "H/30 * * * *"
     builders:
         - shell: |
             export PYTHONPATH=$PYTHONPATH:/opt/scanning

--- a/api_poll/api-server-poll.yml
+++ b/api_poll/api-server-poll.yml
@@ -14,7 +14,7 @@
     description: |
         Managed by Jenkins Job Builder, do not edit manually!
     triggers:
-      - timed: "*/30 * * * *"
+      - timed: "H/2 * * * *"
     builders:
         - shell: |
             export PYTHONPATH=$PYTHONPATH:/opt/scanning

--- a/api_poll/api-server-poll.yml
+++ b/api_poll/api-server-poll.yml
@@ -14,7 +14,7 @@
     description: |
         Managed by Jenkins Job Builder, do not edit manually!
     triggers:
-      - timed: "H * * * *"
+      - timed: "*/30 * * * *"
     builders:
         - shell: |
             export PYTHONPATH=$PYTHONPATH:/opt/scanning

--- a/provisions/roles/api_poll/templates/service_jobs.yaml.j2
+++ b/provisions/roles/api_poll/templates/service_jobs.yaml.j2
@@ -3,7 +3,7 @@
     description: |
         Managed by Jenkins Job Builder, do not edit manually!
     triggers:
-      - timed: "H/60 * * * *"
+      - timed: "*/5 * * * *"
     builders:
         - shell: |
             WORKSPACE=`pwd`

--- a/provisions/roles/api_poll/templates/service_jobs.yaml.j2
+++ b/provisions/roles/api_poll/templates/service_jobs.yaml.j2
@@ -11,4 +11,4 @@
             cd /opt/scanning/api_poll/
             python poll_server.py $WORKSPACE
             cd $WORKSPACE
-            jenkins-jobs --ignore-cache --conf ~/jenkins_jobs.ini update poll_server_generated.yaml
+            jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update poll_server_generated.yaml

--- a/provisions/roles/api_poll/templates/service_jobs.yaml.j2
+++ b/provisions/roles/api_poll/templates/service_jobs.yaml.j2
@@ -3,7 +3,7 @@
     description: |
         Managed by Jenkins Job Builder, do not edit manually!
     triggers:
-      - timed: "H/12 * * * *"
+      - timed: "H/5 * * * *"
     builders:
         - shell: |
             WORKSPACE=`pwd`

--- a/provisions/roles/api_poll/templates/service_jobs.yaml.j2
+++ b/provisions/roles/api_poll/templates/service_jobs.yaml.j2
@@ -3,7 +3,7 @@
     description: |
         Managed by Jenkins Job Builder, do not edit manually!
     triggers:
-      - timed: "*/5 * * * *"
+      - timed: "H/12 * * * *"
     builders:
         - shell: |
             WORKSPACE=`pwd`


### PR DESCRIPTION
 - poll service job now runs every 5 minutes (earlier it was scheduled to run every minute with minute with wrong schedule syntax)
- fixes reusing same worksapce for child projects, removes the `do_not_poll` file before deleting the job
- runs the individual project polling every 30 minutes, earlier it was scheduled for running every hour