### PR TITLE
Adds ability to refresh access token before every weekly scan

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,4 +19,4 @@ ACCESS_TOKEN_FILE = ("/opt/scanning/atomic_scanners/"
                      "scanner-analytics-integration/osio_token.txt")
 
 ANALYTICS_SCANNER_CONTEXT = \
-    "/opt/scanning/atomic_scanners/scannaer-analytics-integration/"
+    "/opt/scanning/atomic_scanners/scanner-analytics-integration/"

--- a/config.py
+++ b/config.py
@@ -8,3 +8,15 @@ ALERTS = ["problem"]
 # alerts will be added in this repo and pushed upon scan completion
 GITREPO = ""
 GITBRANCH = "master"
+
+#===================OSIO access token config================
+# place where refresh token needs to be sourced
+REFRESH_TOKEN_FILE = "/opt/scanning/refresh_token.txt"
+
+# place where the access token will be exported via this
+# script
+ACCESS_TOKEN_FILE = ("/opt/scanning/atomic_scanners/"
+                     "scanner-analytics-integration/osio_token.txt")
+
+ANALYTICS_SCANNER_CONTEXT = \
+    "/opt/scanning/atomic_scanners/scannaer-analytics-integration/"

--- a/provisions/roles/weeklyscan/templates/weekly_rhel_scan.yaml.j2
+++ b/provisions/roles/weeklyscan/templates/weekly_rhel_scan.yaml.j2
@@ -6,4 +6,5 @@
         - timed: "59 11 * * 6"
     builders:
         - shell: |
+            sudo PYTHONPATH=/opt/scanning python /opt/scanning/script/refresh_osio_token.py
             sudo PYTHONPATH=/opt/scanning python /opt/scanning/scripts/weeklyscan.py

--- a/refresh_token.txt
+++ b/refresh_token.txt
@@ -1,0 +1,3 @@
+Dummy referesh token, replace this text with actual refresh token.
+Refer doc https://fabric8-services.github.io/fabric8-auth/reference.html#_offline_tokens
+for more details.

--- a/scripts/refresh_osio_token.py
+++ b/scripts/refresh_osio_token.py
@@ -45,7 +45,8 @@ def rebuilt_analytics_scanner(access_token):
 
     command = """\
 cd {CONTEXT} && \
-docker build -t scanner-analytics-integration:rhel7 -f Dockerfile.rhel7 . && \
+sudo docker build -t scanner-analytics-integration:rhel7 -f \
+Dockerfile.rhel7 . && \
 cd - """
     command = command.format(CONTEXT=ANALYTICS_SCANNER_CONTEXT)
     return run_cmd(command, shell=True)

--- a/scripts/refresh_osio_token.py
+++ b/scripts/refresh_osio_token.py
@@ -24,10 +24,10 @@ def refresh_token():
     """
     command = """\
 curl -H "Content-Type: application/json" -X POST -d \
-'{"refresh_token":"{REFRESH_TOKEN}"}' \
+'{"refresh_token":"%s"}' \
 https://auth.openshift.io/api/token/refresh """
 
-    command = command.format(open(REFRESH_TOKEN_FILE).read().strip())
+    command = command % open(REFRESH_TOKEN_FILE).read().strip()
     access_token = run_cmd(command, shell=True)
     if not access_token:
         print ("Error fetching access token")
@@ -40,7 +40,7 @@ def rebuilt_analytics_scanner(access_token):
     """
     Rebuilt the analytics-scanner
     """
-    with open(ACCESS_TOKEN_FILE) as fin:
+    with open(ACCESS_TOKEN_FILE, "w") as fin:
         fin.write(access_token)
 
     command = """\

--- a/scripts/refresh_osio_token.py
+++ b/scripts/refresh_osio_token.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python2
+
+"""
+This script generates OSIO access token based on refresh
+token sourced in the referenced file. After generating
+access token, its exported at referenced file.
+
+This referenced file for exporting the access token,
+should go inside analytics-integration scanner. Thus
+analytics-integration scanner is also rebuilt.
+"""
+
+
+import sys
+
+from scanning.lib.command import run_cmd
+from config import REFRESH_TOKEN_FILE, ACCESS_TOKEN_FILE, \
+    ANALYTICS_SCANNER_CONTEXT
+
+
+def refresh_token():
+    """
+    Refreshes an access token using refresh_token referenced
+    """
+    command = """\
+curl -H "Content-Type: application/json" -X POST -d \
+'{"refresh_token":"{REFRESH_TOKEN}"}' \
+https://auth.openshift.io/api/token/refresh """
+
+    command = command.format(open(REFRESH_TOKEN_FILE).read().strip())
+    access_token = run_cmd(command, shell=True)
+    if not access_token:
+        print ("Error fetching access token")
+        sys.exit(1)
+
+    return access_token
+
+
+def rebuilt_analytics_scanner(access_token):
+    """
+    Rebuilt the analytics-scanner
+    """
+    with open(ACCESS_TOKEN_FILE) as fin:
+        fin.write(access_token)
+
+    command = """\
+cd {CONTEXT} && \
+docker build -t scanner-analytics-integration:rhel7 -f Dockerfile.rhel7 . && \
+cd - """
+    command = command.format(CONTEXT=ANALYTICS_SCANNER_CONTEXT)
+    return run_cmd(command, shell=True)
+
+
+if __name__ == "__main__":
+    # grab the access token
+    print ("Grabbing an access token using refresh token..")
+    access_token = refresh_token()
+    # rebuilt the client analytics-integration-scanner with
+    # access token so that it can talk to analytics/gemini api server
+    print ("Rebuilding analytics-integration-scanner with new access token..")
+    response = rebuilt_analytics_scanner(access_token)
+    print (response)

--- a/scripts/refresh_osio_token.py
+++ b/scripts/refresh_osio_token.py
@@ -28,6 +28,12 @@ curl -H "Content-Type: application/json" -X POST -d \
 https://auth.openshift.io/api/token/refresh """
 
     command = command % open(REFRESH_TOKEN_FILE).read().strip()
+
+    # curl returns a complete json with multiple fields
+    # we just want the access_token value (string) inside
+    # token dictionary
+    command = command + " | jq -r .token.access_token"
+
     access_token = run_cmd(command, shell=True)
     if not access_token:
         print ("Error fetching access token")

--- a/scripts/weeklyscan.py
+++ b/scripts/weeklyscan.py
@@ -11,6 +11,7 @@ import logging
 import os
 import random
 import string
+import sys
 
 from scanning.lib.queue import JobQueue
 from scanning.lib.log import load_logger
@@ -129,7 +130,7 @@ class WeeklyScan(object):
         if not scan_gitpath:
             self.logger.fatal(
                 "Failed to create dir in git repo. Aborting weekly scan.")
-            return None
+            sys.exit(1)
 
         for image in images:
             # create logs dir


### PR DESCRIPTION
OSIO access token needs to be refreshed in analytics-integration-scanner to talk to gemini api service deployed on osio.
To achieve this, we are going ahead with offline token approach as mentioned in docs [here](https://fabric8-services.github.io/fabric8-auth/reference.html#_offline_tokens).

In this PR
 - We have a dummy file to update with the actual refresh token ( dev needs to update that during deployment) - filename `refresh_token.txt`
 - A script which uses the refresh token from `refresh_token.txt` file and grabs a new access token
 - The script exports the new access token received in `/opt/scanning/atomic_scanners/scanner-analytics-scanner/osio_token.txt` file
- The script rebuilds the analytics-integration scanner after new access token is exported
- This workflow is executed before every weekly scan