### PR TITLE
Adds ability to understand missing version-lock/dependency file

### DIFF
--- a/api_poll/api-server-poll.yml
+++ b/api_poll/api-server-poll.yml
@@ -34,7 +34,16 @@
                   STATUS_CODE=$(sudo SERVER={analytics_server} IMAGE_NAME={image_under_test} GITURL={git_url} GITSHA={git_sha} atomic scan --verbose --scanner=analytics-integration --scan_type=report {image_under_test}|grep api_status_code|cut -f2 -d ":"|cut -c2-4)
                   if [ "$STATUS_CODE" == "200" ]; then
                       echo "Success"
+                      # gemini_report=True marks here that api server has reported something
+                      # in this case it has reported that, it has generated the report
                       gemini_report=True
+                      touch do_not_poll
+                      python /opt/scanning/api_poll/send_scan_data_to_tube.py  {analytics_server} {image_under_test} {git_url} {git_sha} {logs_dir} {scan_gitpath} $gemini_report
+                  elif [ "$STATUS_CODE" == "400" ]; then
+                      echo "dependency/version-lock file is absent in referenced Git repo. Report can't be generated at server."
+                      # gemini_report=False marks here that api server has nothing to report
+                      # as the referenced git repo doesn't have version-lock/dependency file.
+                      gemini_report=False
                       touch do_not_poll
                       python /opt/scanning/api_poll/send_scan_data_to_tube.py  {analytics_server} {image_under_test} {git_url} {git_sha} {logs_dir} {scan_gitpath} $gemini_report
                   else

--- a/atomic_scanners/scanner-analytics-integration/integration.py
+++ b/atomic_scanners/scanner-analytics-integration/integration.py
@@ -136,8 +136,10 @@ def get_request(endpoint, api, data):
                 url, data)
         return False, error + " Error: " + str(e), 0
     else:
-        # requests.codes.ok == 200
-        if r.status_code == requests.codes.ok:
+        # requests.codes.ok == 200 or
+        # check for 400 code - as this is a valid response
+        # as per the workflow
+        if r.status_code in [requests.codes.ok, 400]:
             return True, json.loads(r.text), r.status_code
         else:
             msg = "Returned {} status code for {}. {}".format(
@@ -298,8 +300,14 @@ class AnalyticsIntegration(object):
         self.json_out["Successful"] = True
         current_time = datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
         self.json_out["Finished Time"] = current_time
-        self.json_out["Summary"] = resp.get(
-            "summary", "Check detailed report for more info.")
+        if status_code == 400:
+            self.json_out["Summary"] = resp.get(
+                "summary",
+                "Report can't be generated at server as source git repo has "
+                "missing dependency/lock/manifest file.")
+        else:
+            self.json_out["Summary"] = resp.get(
+                "summary", "Check detailed report for more info.")
         self.json_out["Scan Results"] = resp
         self.json_out["api"] = self.api
         self.json_out["api_data"] = self.data

--- a/atomic_scanners/scanner-analytics-integration/integration.py
+++ b/atomic_scanners/scanner-analytics-integration/integration.py
@@ -333,7 +333,8 @@ class Scanner(object):
             status, output = per_scan_object.run()
             print ("Scanner execution status: {}".format(status))
             print ("api_status_code: {}".format(
-                output.get("api_status_code", 404)))
+                output.get("api_status_code",
+                           "Unable to retrieve status code!")))
 
             # Write scan results to json file
             out_path = os.path.join(OUTDIR, container)

--- a/workers/scan.py
+++ b/workers/scan.py
@@ -46,7 +46,11 @@ class ScanWorker(BaseWorker):
         scanners_data.pop("logs", None)
 
         # presence of `gemini_report` hints if polling is done or not
-        # following will be executed after container is registered
+        # if its present, it means, the scan job is coming after polling
+        # and report api call needs to be made
+
+        # if "gemini_report" is absent in job, it means, the job needs
+        # to be put for polling
         if "gemini_report" not in job:
             # copy the job in another var to avoid action var overwrite
             poll_job = job.copy()


### PR DESCRIPTION
API server will return 400 status code if version-locl/dependency file
 is absent in referenced Git repo.
    
  We need to make client and subsequent workflow aware of this change and behave
   accordingly.
    
      Current behavior:
      if received a 400 status code from api server for report api call
       - print the message on jenkins job console output
       - stop polling for report any further
       - send the job to scan tube
       - the scanner execution wrapper script now understand's 400 code
       - the scnner execution wrapper script will report about missing version-lock/dependency file
