### PR TITLE
Cleans up unneeded scanner result file generated in Jenkins polling job

### DIFF
--- a/api_poll/api-server-poll.yml
+++ b/api_poll/api-server-poll.yml
@@ -30,8 +30,23 @@
 
             if [ $COUNTER -lt 48 ]; then
                 if [ ! -f do_not_poll ]; then
+
                   sudo docker tag registry.access.redhat.com/rhel7:latest {image_under_test}
-                  STATUS_CODE=$(sudo SERVER={analytics_server} IMAGE_NAME={image_under_test} GITURL={git_url} GITSHA={git_sha} atomic scan --verbose --scanner=analytics-integration --scan_type=report {image_under_test}|grep api_status_code|cut -f2 -d ":"|cut -c2-4)
+
+                  echo "Running the analytics-scanner report scan_type and finding the status_code returned from API server.."
+
+                  sudo SERVER={analytics_server} IMAGE_NAME={image_under_test} GITURL={git_url} GITSHA={git_sha} atomic scan --verbose --scanner=analytics-integration --scan_type=report {image_under_test} > scanner_response.txt
+
+                  cat scanner_response.txt
+
+                  STATUS_CODE=$(cat scanner_response.txt |grep api_status_code | cut -f2 -d ":" | cut -c2-4)
+
+                  OUTPUT_FILE=$(cat scanner_response.txt | grep "Files associated with this scan are in" | cut -d ' ' -f 8 | sed 's/\.//')
+
+                  echo "Removing the unneeded scanner results file $OUTPUT_FILE"
+
+                  sudo rm -rf $OUTPUT_FILE scanner_response.txt
+
                   if [ "$STATUS_CODE" == "200" ]; then
                       echo "Success"
                       # gemini_report=True marks here that api server has reported something


### PR DESCRIPTION
Scanner is executed as part of Jenkins polling job and GET REST
API's response code is monitored for processing of poll job.
With every run of poll job, scanner was exporting a result file
on local file system, which was piling up and consuming disk space.
 
Adds clean up mechanism for removing the scanner result file generated
in jenkins job itself. The rest of the scanners executed via scan-worker
are handeled by itself for clean up.
